### PR TITLE
Add support for multi lines message

### DIFF
--- a/r7insight_lambdaCW.py
+++ b/r7insight_lambdaCW.py
@@ -17,11 +17,16 @@ REGION = os.environ.get('region')
 ENDPOINT = f'{REGION}.data.logs.insight.rapid7.com'
 PORT = 20000
 TOKEN = os.environ.get('token')
-LINE = u'\u2028'
+FAKE_NEWLINE = u'\u2028'
 
 
 def treat_message(message):
-    return message.replace('\n',LINE)
+	"""
+	Replace newline characters in the supplied message with "fake"
+	unicode line breaks (\u2028), so that the message can be sent
+	as a single log event.
+	"""		
+    return message.replace('\n', FAKE_NEWLINE)
 
 
 def lambda_handler(event, context):

--- a/r7insight_lambdaCW.py
+++ b/r7insight_lambdaCW.py
@@ -17,6 +17,11 @@ REGION = os.environ.get('region')
 ENDPOINT = f'{REGION}.data.logs.insight.rapid7.com'
 PORT = 20000
 TOKEN = os.environ.get('token')
+LINE = u'\u2028'
+
+
+def treat_message(message):
+    return message.replace('\n',LINE)
 
 
 def lambda_handler(event, context):
@@ -37,7 +42,8 @@ def lambda_handler(event, context):
                 msg = f"{TOKEN} {json.dumps(log_event['extractedFields'])}\n"
                 sock.sendall(msg.encode('utf-8'))
             except KeyError:
-                msg = f"{TOKEN} {log_event['message']}\n"
+                treated_msg=treat_message(log_event['message'])
+                msg = f"{TOKEN} {treated_msg}\n"
                 sock.sendall(msg.encode('utf-8'))
 
     sock.close()

--- a/r7insight_lambdaCW.py
+++ b/r7insight_lambdaCW.py
@@ -42,7 +42,7 @@ def lambda_handler(event, context):
                 msg = f"{TOKEN} {json.dumps(log_event['extractedFields'])}\n"
                 sock.sendall(msg.encode('utf-8'))
             except KeyError:
-                treated_msg=treat_message(log_event['message'])
+                treated_msg = treat_message(log_event['message'])
                 msg = f"{TOKEN} {treated_msg}\n"
                 sock.sendall(msg.encode('utf-8'))
 


### PR DESCRIPTION
Messages which contain new line are not getting pushed from CloudWatch due to encoding issues.

The new line character is first converted to Unicode. Then the message is appended with a new line before sending to the socket connection.

Sharing the test data for the function to view the difference.

event={'awslogs': {'data': 'H4sIAAAAAAAAAE2QW08bMRCF/4plXorEJr7Et0WViOgWkFIJ2O1L0yjaJhayml0vtkMaIf474wQK9ot95sxnn3nGnY2xfbDNfrC4xN+mzXT5o6rr6VWFz7Df9TaATKiR1AgjtNIgb/zDVfDbASrjdhfHYR3Hro+p7Vd27Fi+xo3fPW5t2B/tdQq27cB/qIIWt3/iKrghOd9/d5tkQ8Tl/FguujaCUGRGAc2xCO3g1qoY9lzixQFYPdk+5ZZn7NbA5ZLJiZJEKcOkIpxTRRmnXBH4ueaCS6EMxFBaMkLAIKgxE53TJAczSG0HcShQqNSUTrSgZ++zAfwJasBVIkYYLYgqKG+IKRktxWQEVk3kr9/9CfoZbbi49jGVKLpu2Lhl8D7NP50X6AKhOSWjvBnTC4Ru1sClhislSIbc5bEt0+E9MSKEaK0QmvnV3zeRZBEWuve7uIwwiBJRdLzZf23negtIYNVVg/6n+/oR7jyXZtVlg+pZVd1+Eafn+GXx8grpQBRCDQIAAA=='}}
