### PR TITLE
fix: replace tabs with spaces to fix syntax error

### DIFF
--- a/r7insight_lambdaCW.py
+++ b/r7insight_lambdaCW.py
@@ -21,11 +21,11 @@ FAKE_NEWLINE = u'\u2028'
 
 
 def treat_message(message):
-	"""
-	Replace newline characters in the supplied message with "fake"
-	unicode line breaks (\u2028), so that the message can be sent
-	as a single log event.
-	"""		
+    """
+    Replace newline characters in the supplied message with "fake"
+    unicode line breaks (\u2028), so that the message can be sent
+    as a single log event.
+    """
     return message.replace('\n', FAKE_NEWLINE)
 
 


### PR DESCRIPTION
Hi all,

Upon working my way through the documented setup with the latest version of the `master` branch (I've done this before with earlier versions), I noted that each invocation of the lambda resulted in the following error:
```
Syntax error in module 'r7insight_lambdaCW': unindent does not match any outer indentation level (r7insight_lambdaCW.py, line 29)
```

Replacing the tabs in the multiline string as in this PR resolves the issue (my logs are indeed showing up in Rapid7 as desired now), so just want to save anyone else the trouble.

Thanks!