### PR TITLE
fix: add connection retry

### DIFF
--- a/r7insight_lambdaCW.py
+++ b/r7insight_lambdaCW.py
@@ -69,13 +69,20 @@ def create_socket():
         suppress_ragged_eofs=True,
         server_hostname=ENDPOINT,
     )
-    try:
-        logger.info(f'Connecting to {ENDPOINT}:{PORT}')
-        s.connect((ENDPOINT, PORT))
-        return s
-    except socket.error as exc:
-        logger.error(f'Exception socket.error : {exc}')
-
+    
+    # Retry logic to handle connection errors
+    max_retries = 3
+    for attempt in range(max_retries):
+        try:
+            logger.info(f'Connecting to {ENDPOINT}:{PORT} (attempt {attempt + 1}/{max_retries})')
+            s.connect((ENDPOINT, PORT))
+            return s
+        except socket.error as exc:
+            if attempt == max_retries - 1:
+                logger.error(f'Failed to connect after {max_retries} attempts. Final exception: {exc}')
+                raise # Raise the exception to the caller
+            else:
+                logger.warning(f'Connection attempt {attempt + 1} failed: {exc}. Retrying...')
 
 def validate_uuid(uuid_string):
     try:


### PR DESCRIPTION
📌 PR: Add Connection Retry Logic to r7insight_lambdaCW
This pull request introduces improved connection reliability for the AWS Lambda log forwarder by adding retry logic around the network connection to the Rapid7 Insight endpoint.

✅ What Changed

- Implements connection retry logic when sending logs from AWS CloudWatch to Rapid7.
- Enhances resilience against transient network failures (e.g., timeouts, dropped connections).
- Reduces potential data loss by retrying failed HTTP/Insight API connections.

💡 Why This Matters
Without retries, occasional connectivity interruptions can cause the Lambda function to fail to forward logs, which could result in gaps in log ingestion due to misconfigurations. The added retry mechanism:

- Improves robustness in unreliable network conditions.
- Aligns log forwarding behaviour with expected reliability standards.
- Helps ensure CloudWatch logs reach Rapid7 Insight even under intermittent connection issues.

I have tested this change over the course of the past week and can see a significant improvement in Lambda functions failures. 

<img width="423" height="243" alt="image" src="https://github.com/user-attachments/assets/03694d98-fd04-4035-bf6d-cade7c48cf12" />
